### PR TITLE
Change endpoint for reading blobs and remove fetchContent method

### DIFF
--- a/backbone-gitlab.coffee
+++ b/backbone-gitlab.coffee
@@ -327,7 +327,7 @@ GitLab = (url, token) ->
       options = options || {}
       baseURL = "#{root.url}/projects/#{@project.escaped_path()}/repository"
       if method.toLowerCase() == "read"
-        options.url = "#{baseURL}/blobs/#{@branch}"
+        options.url = "#{baseURL}/files?file_path=#{@get('file_path').replace('/','%2F')}&ref=#{@branch}"
       else
         options.url = "#{baseURL}/files"
 
@@ -367,21 +367,11 @@ GitLab = (url, token) ->
       else
         "Updated #{@get("file_path")}"
 
-    fetchContent: (options) ->
-      @fetch(
-        _.extend(
-          dataType:"html"
-          data: filepath: @get("file_path")
-        , options)
-      )
-
     parse: (response, options) ->
-      # if response is blob content from /blobs
-      if _.isString(response)
-        content: response
-      # if response is blob object from /files
-      else
-        response
+      if response.encoding is "base64"
+        response.content = atob(response.content)
+        response.encoding = "text"
+      response
   )
 
   # Tree

--- a/backbone-gitlab.js
+++ b/backbone-gitlab.js
@@ -422,7 +422,7 @@
         options = options || {};
         baseURL = "" + root.url + "/projects/" + (this.project.escaped_path()) + "/repository";
         if (method.toLowerCase() === "read") {
-          options.url = "" + baseURL + "/blobs/" + this.branch;
+          options.url = "" + baseURL + "/files?file_path=" + (this.get('file_path').replace('/', '%2F')) + "&ref=" + this.branch;
         } else {
           options.url = "" + baseURL + "/files";
         }
@@ -464,22 +464,12 @@
           return "Updated " + (this.get("file_path"));
         }
       },
-      fetchContent: function(options) {
-        return this.fetch(_.extend({
-          dataType: "html",
-          data: {
-            filepath: this.get("file_path")
-          }
-        }, options));
-      },
       parse: function(response, options) {
-        if (_.isString(response)) {
-          return {
-            content: response
-          };
-        } else {
-          return response;
+        if (response.encoding === "base64") {
+          response.content = atob(response.content);
+          response.encoding = "text";
         }
+        return response;
       }
     });
     this.Tree = this.Collection.extend({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "backbone-gitlab",
-  "version" : "0.8.2",
+  "version" : "0.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/oreillymedia/backbone-gitlab"

--- a/test/canned/projects/owner%2Fproject/repository/files/index?file_path=subfolder%2Fmaster.txt&ref=master.get.json
+++ b/test/canned/projects/owner%2Fproject/repository/files/index?file_path=subfolder%2Fmaster.txt&ref=master.get.json
@@ -1,0 +1,10 @@
+{
+  "file_name": "master.txt",
+  "file_path": "subfolder/master.txt",
+  "size": 389,
+  "encoding": "base64",
+  "content": "SGVsbG8h",
+  "ref": "master",
+  "blob_id": "a13655b69ba37178e0913f990c5613dbcea278ce",
+  "commit_id": "a0a9ec83543a804dc13c4de3ac714c43ee57f0fb"
+}

--- a/test/canned/projects/owner%2Fproject/repository/files/index?file_path=subfolder%2Fslave.txt&ref=slave.get.json
+++ b/test/canned/projects/owner%2Fproject/repository/files/index?file_path=subfolder%2Fslave.txt&ref=slave.get.json
@@ -1,0 +1,10 @@
+{
+  "file_name": "02-copyright.html",
+  "file_path": "02-copyright.html",
+  "size": 389,
+  "encoding": "base64",
+  "content": "PHNlY3Rpb24gZGF0YS10eXBlPSJjb3B5cmlnaHQtcGFnZSI+CjxoMT57eyB0\naXRsZSB9fTwvaDE+Cgo8cD5ieSBBdXRob3IgTmFtZTwvcD4KCjxwPkNvcHly\naWdodCAoYykgMjAxNDwvcD4KCjxwPlRoaXMgaXMgYSBsZWdhbCBub3RpY2Ug\nb2Ygc29tZSBraW5kLiBZb3UgY2FuIGFkZCBub3RlcyBhYm91dCB0aGUga2lu\nZCBvZiBsaWNlbnNlIHlvdSBhcmUgdXNpbmcgZm9yIHlvdXIgYm9vayAoZS5n\nLiwgQ3JlYXRpdmUgQ29tbW9ucyksIG9yIGFueXRoaW5nIGVsc2UgeW91IGZl\nZWwgeW91IG5lZWQgdG8gc3BlY2lmeS48L3A+Cgo8cD5JZiB5b3VyIGJvb2sg\naGFzIGFuIElTQk4gb3IgYSBib29rIElEIG51bWJlciwgYWRkIGl0IGhlcmUg\nYXMgd2VsbC4gYXNkZjwvcD4KPC9zZWN0aW9uPgo=\n",
+  "ref": "master",
+  "blob_id": "a13655b69ba37178e0913f990c5613dbcea278ce",
+  "commit_id": "a0a9ec83543a804dc13c4de3ac714c43ee57f0fb"
+}

--- a/test/spec/gitlab_spec.coffee
+++ b/test/spec/gitlab_spec.coffee
@@ -725,13 +725,12 @@ describe("GitLab", ->
       expect(-> new gitlab.Blob()).toThrow("You have to initialize GitLab.Blob with a GitLab.Project model")
     )
 
-    describe("fetchContent()", ->
+    describe("fetch()", ->
 
       it("should fetch the blob contents and merge with other data", (done) ->
         spyOnAjax()
-        masterBlob.fetchContent({success: ->
-          expect(lastAjaxCall().args[0].url).toEqual(url + "/projects/owner%2Fproject/repository/blobs/master")
-          expect(lastAjaxCallData().filepath).toEqual("subfolder/master.txt")
+        masterBlob.fetch({success: ->
+          expect(lastAjaxCall().args[0].url).toEqual(url + "/projects/owner%2Fproject/repository/files?file_path=subfolder%2Fmaster.txt&ref=master")
           expect(masterBlob.get("content")).toEqual("Hello!")
           expect(masterBlob.get("name")).toEqual("master.txt")
           expect(masterBlob.get("file_path")).toEqual("subfolder/master.txt")
@@ -741,8 +740,8 @@ describe("GitLab", ->
 
       it("should use branch if specified", ->
         spyOnAjax()
-        slaveBlob.fetchContent()
-        expect(lastAjaxCall().args[0].url).toEqual(url + "/projects/owner%2Fproject/repository/blobs/slave")
+        slaveBlob.fetch()
+        expect(lastAjaxCall().args[0].url).toEqual(url + "/projects/owner%2Fproject/repository/files?file_path=subfolder%2Fslave.txt&ref=slave")
       )
     )
 
@@ -888,7 +887,7 @@ describe("GitLab", ->
       it("should parse string response from /blobs", (done) ->
         spyOnAjax()
         masterBlob.set("content", "Goodbye!")
-        masterBlob.fetchContent success: ->
+        masterBlob.fetch success: ->
           expect(masterBlob.get("content")).toEqual("Hello!")
           done()
       )


### PR DESCRIPTION
This will bump backbone-gitlab to 0.9.0

Fetching a `Blob` now uses the `repository/files` endpoint and gets content and blob_id and commit_id. Makes a change to `Blob.parse` to automatically decode base64.

**removes** `Blob.fetchContent` in favor of using `Blob.fetch`
