### PR TITLE
Remove newlines from base64 content before parsing

### DIFF
--- a/backbone-gitlab.coffee
+++ b/backbone-gitlab.coffee
@@ -378,7 +378,7 @@ GitLab = (url, token) ->
 
     parse: (response, options) ->
       if response.encoding is "base64"
-        response.content = atob(response.content)
+        response.content = atob(response.content.replace(/\n/g,''))
         response.encoding = "text"
       response
   )

--- a/backbone-gitlab.js
+++ b/backbone-gitlab.js
@@ -474,7 +474,7 @@
       },
       parse: function(response, options) {
         if (response.encoding === "base64") {
-          response.content = atob(response.content);
+          response.content = atob(response.content.replace(/\n/g, ''));
           response.encoding = "text";
         }
         return response;


### PR DESCRIPTION
Safari has problems with base64 with newlines in it which is what Gitlab returns.
