### PR TITLE
Supply per_page parameter with API call for trees

### DIFF
--- a/backbone-gitlab.coffee
+++ b/backbone-gitlab.coffee
@@ -465,6 +465,7 @@ GitLab = (url, token) ->
       @project = options.project
       @branch = options.branch || "master"
       @trees = []
+      @per_page = options.per_page || 100
 
       if options.path
         @path = options.path
@@ -475,6 +476,7 @@ GitLab = (url, token) ->
       options.data = options.data || {}
       options.data.path = @path if @path
       options.data.ref_name = @branch
+      options.data.per_page = @per_page
       root.Collection.prototype.fetch.apply(this, [options])
 
     parse: (resp, xhr) ->

--- a/backbone-gitlab.js
+++ b/backbone-gitlab.js
@@ -580,6 +580,7 @@
         this.project = options.project;
         this.branch = options.branch || "master";
         this.trees = [];
+        this.per_page = options.per_page || 100;
         if (options.path) {
           this.path = options.path;
           return this.name = _.last(options.path.split("/"));
@@ -592,6 +593,7 @@
           options.data.path = this.path;
         }
         options.data.ref_name = this.branch;
+        options.data.per_page = this.per_page;
         return root.Collection.prototype.fetch.apply(this, [options]);
       },
       parse: function(resp, xhr) {

--- a/test/spec/gitlab_spec.coffee
+++ b/test/spec/gitlab_spec.coffee
@@ -736,6 +736,29 @@ describe("GitLab", ->
         expect(lastAjaxCallData().ref_name).toEqual("slave")
       )
 
+      it("should call correct URL with default per_page parameter of 100", ->
+        spyOnAjax()
+        tree = new gitlab.Tree([]
+        ,
+          project:project
+          path:"subfolder"
+        )
+        tree.fetch()
+        expect(lastAjaxCallData().per_page).toEqual(100)
+      )
+
+      it("should call correct URL with supplied per_page parameter", ->
+        spyOnAjax()
+        tree = new gitlab.Tree([]
+        ,
+          project:project
+          path:"subfolder"
+          per_page: 60
+        )
+        tree.fetch()
+        expect(lastAjaxCallData().per_page).toEqual(60)
+      )
+
       it("should parse trees and blobs", (done) ->
         tree = new gitlab.Tree([], project:project)
         tree.fetch({

--- a/test/spec/gitlab_spec.coffee
+++ b/test/spec/gitlab_spec.coffee
@@ -736,7 +736,7 @@ describe("GitLab", ->
         expect(lastAjaxCallData().ref_name).toEqual("slave")
       )
 
-      it("should call correct URL with default per_page parameter of 100", ->
+      it("should override per_page default with maximum allowed value when not supplied", ->
         spyOnAjax()
         tree = new gitlab.Tree([]
         ,


### PR DESCRIPTION
Override per_page default of 20 (as of GitLab API v4) with the maximum allowed value (100) or a supplied value.