### PR TITLE
ATLAS-169: Support inline pagination on tree listings

### DIFF
--- a/backbone-gitlab.coffee
+++ b/backbone-gitlab.coffee
@@ -476,7 +476,7 @@ GitLab = (url, token) ->
       options.data = options.data || {}
       options.data.path = @path if @path
       options.data.ref = @branch
-      options.data.per_page = @per_page
+      options.data.per_page ||= @per_page
       root.Collection.prototype.fetch.apply(this, [options])
 
     parse: (resp, xhr) ->

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "backbone": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
-      "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
       "requires": {
         "underscore": ">=1.8.3"
       }
@@ -36,9 +36,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
     },
     "wordwrap": {
       "version": "0.0.3",


### PR DESCRIPTION
GitLab 10.x changed per-request limits on the number of items returned
from the tree listing API, capping at 100 per page with no evident way
to change that as a system-wide configuration. To work around this in
O'Reilly Atlas, we added simple pagination to continue making requests
to the API until all file in a directory are loaded.

This required one change to the Backbone-GitLab API wrapper, to memoize
the per_page option so it's not reset on subsequent requests during
paginated loading. Backport this change to the backbone-gitlab package.